### PR TITLE
Commit failure does not trigger error

### DIFF
--- a/examples/netconf-client.js
+++ b/examples/netconf-client.js
@@ -41,7 +41,7 @@ function commitRollback(value) {
     if (value === true) {
         console.log('Commiting configuration.');
         router.commit(function(err, result) {
-           if (err) {
+           if (result.rpc_reply.commit_results.routing_engine.rpc_error) {
                router.rollback(function (err, rollback_result) {
                    pprint(result);
                    console.log('Commit error, rolling back.')

--- a/lib/netconf.js
+++ b/lib/netconf.js
@@ -253,10 +253,10 @@ Client.prototype.commit = function (callback) {
     this.rpc('commit-configuration', callback);
 };
 Client.prototype.openPrivate = function (callback) {
-    this.rpc('<open-configuration><private/></open-configuration>', callback);
+    this.rpc('open-configuration private', callback);
 };
 Client.prototype.closePrivate = function (callback) {
-    this.rpc('<close-configuration/>', callback);
+    this.rpc('close-configuration', callback);
 };
 Client.prototype.compare = function (callback) {
     const rpcCompare = {

--- a/lib/netconf.js
+++ b/lib/netconf.js
@@ -31,6 +31,7 @@ function Client(params) {
     this.remoteCapabilities = [ ];
     this.idCounter = 100;
     this.rcvBuffer = '';
+    this.debug = params.debug;
 
     // Runtime option tweaks
     this.raw = false;
@@ -44,6 +45,7 @@ function Client(params) {
         valueProcessors: [ xml2js.processors.parseNumbers ],
         attrValueProcessors: [ xml2js.processors.parseNumbers ]
     };
+    this.algorithms = params.algorithms
 }
 Client.prototype = {
     // Message and transport functions.
@@ -70,7 +72,7 @@ Client.prototype = {
             }
         }
 
-        const builder = new xml2js.Builder({ headless: true });
+        const builder = new xml2js.Builder({ headless: false });
         let xml;
         try {
             xml = builder.buildObject(object) + '\n' + DELIM;
@@ -86,7 +88,8 @@ Client.prototype = {
             // Add an event handler to search for our message on data events.
             self.netconf.on('data', function replyHandler() {
                 const replyFound = self.rcvBuffer.search(rpcReply) !== -1;
-                if (replyFound) {
+              
+                 if (replyFound) {
                     const message = self.rcvBuffer.match(rpcReply);
                     self.parse(message[1], callback);
                     // Tidy up, remove matched message from buffer and
@@ -168,13 +171,14 @@ Client.prototype = {
             });
         }).on('error', function (err) {
             self.connected = false;
-            throw (err);
         }).connect({
             host: this.host,
             username: this.username,
             password: this.password,
             port: this.port,
-            privateKey: this.pkey
+            privateKey: this.pkey,
+            debug: this.debug,
+            algorithms: this.algorithms
         });
     },
     sendHello: function () {
@@ -182,7 +186,7 @@ Client.prototype = {
             hello: {
                 $: { xmlns: 'urn:ietf:params:xml:ns:netconf:base:1.0' },
                 capabilities: {
-                    capability: 'urn:ietf:params:xml:ns:netconf:base:1.0'
+                    capability: ['urn:ietf:params:xml:ns:netconf:base:1.0','urn:ietf:params:netconf:base:1.0']
                 }
             }
         };
@@ -205,8 +209,18 @@ Client.prototype.close = function (callback) {
     });
 };
 
+// Cisco specific operations.
+Client.prototype.IOSClose = function (callback) { // Cisco does not send a disconnect so you have to submit something after you close the session. Model: WS-C2960S-48FPD-L SW Version: 12.2(58)SE2
+    const self = this;
+    this.rpc('close-session', function closeSocket(err, reply) {
+        self.rpc('close-session', function closeSocket(err, reply) {
+            return callback(null, reply);
+        });
+    });
+};
+
 // Juniper specific operations.
-Client.prototype.load = function (args, callback) {
+Client.prototype.JunosLoad = function (args, callback) {
     let loadOpts = { };
     if (typeof (args) === 'string') { // Backwards compatible with 0.1.0
         loadOpts = { config: args, action: 'merge', format: 'text' };
@@ -249,19 +263,29 @@ Client.prototype.load = function (args, callback) {
          return callback(null, reply);
      });
 };
-Client.prototype.commit = function (callback) {
-    this.rpc('commit-configuration', callback);
+Client.prototype.JunosCommit = function (callback) {
+    this.rpc('commit-configuration', function checkErrors(err, reply) {
+        if (err) {
+            return callback(err, reply);
+        }
+        // Load errors aren't found in the top-level reply so need to check seperately.
+        const rpcError = result.rpc_reply.commit_results.routing_engine.hasOwnProperty('rpc_error');
+        if (rpcError) {
+            return callback(createError(JSON.stringify(reply), 'rpcError'), null);
+        }
+        return callback(null, reply);
+    });
 };
-Client.prototype.openPrivate = function (callback) {
+Client.prototype.JunosOpenPrivate = function (callback) {
     const rpcOpen = {
         'open-configuration': {'private' : ""}
     };
     this.rpc(rpcOpen, callback);
 };
-Client.prototype.closePrivate = function (callback) {
+Client.prototype.JunosClosePrivate = function (callback) {
     this.rpc('close-configuration', callback);
 };
-Client.prototype.compare = function (callback) {
+Client.prototype.JunosCompare = function (callback) {
     const rpcCompare = {
         'get-configuration': {
             $: { compare: 'rollback', format: 'text' }
@@ -275,10 +299,10 @@ Client.prototype.compare = function (callback) {
         return callback(null, text);
     });
 };
-Client.prototype.rollback = function (callback) {
+Client.prototype.JunosRollback = function (callback) {
     this.rpc('discard-changes', callback);
 };
-Client.prototype.facts = function (callback) {
+Client.prototype.JunosFacts = function (callback) {
     const self = this;
     vasync.parallel({
         funcs: [

--- a/lib/netconf.js
+++ b/lib/netconf.js
@@ -252,6 +252,12 @@ Client.prototype.load = function (args, callback) {
 Client.prototype.commit = function (callback) {
     this.rpc('commit-configuration', callback);
 };
+Client.prototype.openPrivate = function (callback) {
+    this.rpc('<open-configuration><private/></open-configuration>', callback);
+};
+Client.prototype.closePrivate = function (callback) {
+    this.rpc('<close-configuration/>', callback);
+};
 Client.prototype.compare = function (callback) {
     const rpcCompare = {
         'get-configuration': {

--- a/lib/netconf.js
+++ b/lib/netconf.js
@@ -253,7 +253,10 @@ Client.prototype.commit = function (callback) {
     this.rpc('commit-configuration', callback);
 };
 Client.prototype.openPrivate = function (callback) {
-    this.rpc('open-configuration private', callback);
+    const rpcOpen = {
+        'open-configuration': {'private' : ""}
+    };
+    this.rpc(rpcOpen, callback);
 };
 Client.prototype.closePrivate = function (callback) {
     this.rpc('close-configuration', callback);


### PR DESCRIPTION
The function router.commit() does not produce an err when routing engine fails configuration. From what i have seen on an mx480 result.rpc_reply.commit_results.routing_engine.rpc_error will be present when one of the routing engine fails and if it passes it does not exist.