### PR TITLE
Correct floating error condition on connection failure

### DIFF
--- a/lib/netconf.js
+++ b/lib/netconf.js
@@ -131,13 +131,16 @@ Client.prototype = {
                     self.sendHello();
                     stream.on('data', function buffer(chunk) {
                         self.rcvBuffer += chunk;
+                        self.emit('data');
                     }).on('error', function streamErr(err) {
                         self.sshConn.end();
                         self.connected = false;
+                        self.emit('error');
                         throw (err);
                     }).on('close', function handleClose() {
                         self.sshConn.end();
                         self.connected = false;
+                        self.emit('close');
                     }).on('data', function handleHello() {
                         if (self.rcvBuffer.match(DELIM)) {
                             const helloMessage = self.rcvBuffer.replace(DELIM, '');
@@ -181,6 +184,8 @@ Client.prototype = {
             debug: this.debug,
             algorithms: this.algorithms
         });
+
+        return self;
     },
     sendHello: function () {
         const message = {

--- a/lib/netconf.js
+++ b/lib/netconf.js
@@ -12,7 +12,7 @@ function objectHelper(name) {
 function createError(msg, type) {
     const err = new Error(msg);
     err.name = type;
-    
+
     Error.captureStackTrace(err, createError);
     return err;
 }
@@ -88,7 +88,7 @@ Client.prototype = {
             // Add an event handler to search for our message on data events.
             self.netconf.on('data', function replyHandler() {
                 const replyFound = self.rcvBuffer.search(rpcReply) !== -1;
-              
+
                  if (replyFound) {
                     const message = self.rcvBuffer.match(rpcReply);
                     self.parse(message[1], callback);
@@ -171,6 +171,7 @@ Client.prototype = {
             });
         }).on('error', function (err) {
             self.connected = false;
+            callback(err);
         }).connect({
             host: this.host,
             username: this.username,


### PR DESCRIPTION
Case: When an invalid username or password is given, the ssh terminal will fail, previously the error was removed from code, but this would cause the callback to never be fired and the promise chain to be broken

Solution: Promise chain is respected, and the error state properly passed through the code.